### PR TITLE
[fix] 윈도우 맥 eol 호환을 위한 crlf, lf 통일

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,10 @@ module.exports = {
   plugins: ["prettier"],
   ignorePatterns: ["node_modules/"],
   rules: {
-    "prettier/prettier": "error",
+    "linebreak-style": [
+      "error",
+      require("os").EOL === "\r\n" ? "windows" : "unix",
+    ],
+    "prettier/prettier": ["error", { endOfLine: "auto" }],
   },
 };


### PR DESCRIPTION
## 설명

crlf, lf 호환성 버그 수정을 위해 eslint 규칙 추가.

## 테스트

- [x] 로컬 테스트 진행

## 관련 이슈

fix #9 
