### PR TITLE
[fix] Socket 연결 해제시 캐릭터 삭제되지 않던 버그 수정

### DIFF
--- a/src/socket/index.js
+++ b/src/socket/index.js
@@ -15,7 +15,7 @@ module.exports = server => {
     registerCharacterHandler(socket, characterGroup, character);
 
     socket.on('disconnect', () => {
-      delete characterGroup[socket.id];
+      characterGroup.removeCharacterBySocketId(socket.id);
       io.emit('character:disconnection', socket.id);
     });
   };


### PR DESCRIPTION
## 설명

Character Group 객체를 구현하고 delete에 대해서는 적용하지 않아서 생기는 버그였습니다. 

<!--pr에 대한 간단한 설명과 진행한 작업들을 작성해주세요.-->

## 테스트

- [x] 로컬 테스트 진행
<!--로컬 테스트를 진행하고 나서 pr을 올려주세요. -->

## 관련 이슈

<!--close,fix,release 중 하나를 선택해서 작성해주세요. 대괄호는 삭제해주세요. 이슈가 여러개일 경우 s를 끝에 붙여주세요.-->

## Breaking Change

- [ ] yes
- [x] no

<!--의존성, env 파일 등등의 변화로 기존 버전과 호환이 안되는 경우 yes에 체크해주세요-->
