### PR TITLE
[feat] 하나의 소켓 이벤트는 하나의 동작만 하도록 분리

### DIFF
--- a/src/socket/character/index.js
+++ b/src/socket/character/index.js
@@ -1,8 +1,11 @@
 module.exports = (socket, characterGroup, character) => {
   socket.on('character:start', () => {
+    socket.emit('character:myCharacter', character.getCharacterState());
     socket.emit('character:currentCharacter', characterGroup.getCharacterGroupState());
 
     socket.broadcast.emit('character:newCharacter', character.getCharacterState());
+
+    characterGroup.appendCharacter(character);
 
     socket.on('character:move', movementData => {
       character.setCharacterState(movementData.x, movementData.y, movementData.animation);

--- a/src/socket/index.js
+++ b/src/socket/index.js
@@ -10,7 +10,6 @@ module.exports = server => {
 
   const connectionHandler = socket => {
     const character = new Character(450, 350, socket.id);
-    characterGroup.appendCharacter(character);
 
     registerCharacterHandler(socket, characterGroup, character);
 


### PR DESCRIPTION
## 설명

현재는 `currentCharacter` 이벤트로 내 캐릭터와 원래 맵에 있던 캐릭터들의 정보를 한번에 받아오는 상황입니다. 하지만 Client에서 조건문을 통해서 내 캐릭터와 타인의 캐릭터을 구분해서 생성하고 있기 때문에 분리했습니다.

<!--pr에 대한 간단한 설명과 진행한 작업들을 작성해주세요.-->

## 테스트

- [x] 로컬 테스트 진행
<!--로컬 테스트를 진행하고 나서 pr을 올려주세요. -->

## 관련 이슈

close #22

<!--close,fix,release 중 하나를 선택해서 작성해주세요. 대괄호는 삭제해주세요. 이슈가 여러개일 경우 s를 끝에 붙여주세요.-->

## Breaking Change

- [ ] yes
- [x] no

<!--의존성, env 파일 등등의 변화로 기존 버전과 호환이 안되는 경우 yes에 체크해주세요-->
