### PR TITLE
Feature/signin http method post

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
   extends: ['eslint:recommended', 'plugin:prettier/recommended'],
   ignorePatterns: ['node_modules/'],
   parserOptions: {
-    ecmaVersion: 8,
+    ecmaVersion: 11,
   },
   rules: {
     'no-unused-vars': 1,

--- a/src/api/auth/index.js
+++ b/src/api/auth/index.js
@@ -2,7 +2,7 @@ const ApiClient = require('@/api');
 
 class AuthClient extends ApiClient {
   async validationOAuthToken(url, oAuthtoken) {
-    const header = { Authorization: oAuthtoken };
+    const header = { Authorization: `Bearer ${oAuthtoken}` };
     const { id: userId } = await this.instance.get(url, header);
     return userId;
   }

--- a/src/controllers/auth/index.js
+++ b/src/controllers/auth/index.js
@@ -4,8 +4,7 @@ const UserService = require('@/services/user');
 
 exports.signin = async (request, response) => {
   try {
-    const oAuthToken = request.headers.authorization;
-    const { vendor } = request.query;
+    const { vendor, oAuthToken } = request.body;
 
     const userId = await AuthService.validateOAuthToken(vendor, oAuthToken);
     const user = await UserService.getUser(userId);

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -1,7 +1,7 @@
 const router = require('express').Router();
 const AuthController = require('@/controllers/auth');
 
-router.get('/signin', AuthController.signin);
+router.post('/signin', AuthController.signin);
 router.get('/token', AuthController.validateToken);
 
 module.exports = router;


### PR DESCRIPTION
## 설명

로그인 api 의 http method를 get에서 post로 변경하였습니다. 이유는 다음과 같은데요.

- 기존의 get을 사용할 경우, header의 authentication 을 사용해서 전달하였는데 우리 서버자체의 token과 충돌할 위험이 있었습니다. 우리 서버자체의 token만 header의 authentication에 들어가도록 설정하였습니다.
- 보안상의 이유로 get을 로그인에 사용하지 않는다고 합니다. post보다 덜 암호화 되어 보내지며 서버에서 적극적으로 캐싱을 하기 때문에 보안상에 위험이 있다고 합니다.

이외에도 eslint ecmaVersion 버전 수정 작업이 있었습니다.

## 테스트

- [x] 로컬 테스트 진행
<!--로컬 테스트를 진행하고 나서 pr을 올려주세요. -->

## 관련 이슈


## Breaking Change

- [ ] yes
- [x] no

<!--의존성, env 파일 등등의 변화로 기존 버전과 호환이 안되는 경우 yes에 체크해주세요-->
